### PR TITLE
feat: websocket proxy

### DIFF
--- a/templates/nginx/location-https-redirect.j2
+++ b/templates/nginx/location-https-redirect.j2
@@ -1,0 +1,6 @@
+{% extends "location.j2" %}
+
+{% block main_location %}
+
+        return 301 https://{{ domainConfig.domain }}$request_uri;
+{% endblock %}

--- a/templates/nginx/location-reverseproxy.j2
+++ b/templates/nginx/location-reverseproxy.j2
@@ -1,12 +1,24 @@
-{% extends "serverblock.https.j2" %}
+{% extends "location.j2" %}
 
 {% block main_location %}
+
         proxy_pass http://localhost:{~ docker_ports[{{ port_index }}] ~};
+        proxy_http_version 1.1;
         proxy_redirect off;
         proxy_set_header X-Scheme $scheme;
         proxy_set_header Host $host;
         proxy_set_header Referer $http_referer;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Protocol $scheme;
+        proxy_set_header X-Forwarded-Host $http_host;
+
         add_header Strict-Transport-Security 'max-age=15552000; includeSubDomains' always;
+
+{% if ns.path in expose.proxy_websocket_locations|d([]) %}
+        # Websocket proxy
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+{% endif %}
 {% endblock %}

--- a/templates/nginx/location.j2
+++ b/templates/nginx/location.j2
@@ -1,0 +1,18 @@
+{% set locations = expose.proxy_websocket_locations|d([]) + ["/"] %}
+
+{%- set ns = namespace (path = '') %}
+{% for path in locations %}
+{%- set ns.path = path %}
+    location {{ path }} {
+    {%- block main_location %}{%- endblock %}
+
+{% block authentication %}
+{% if domainConfig.security.authentication is defined and domainConfig.security.authentication|selectattr("type", "equalto", "basic")|list | length > 0 %}
+        # Authentication
+        auth_basic           "{{ nginx_basicauth_title }}";
+        auth_basic_user_file "{{ nginx_htpasswd_path }}/.{{ domainConfig.domain }}";
+{% endif %}
+{% endblock %}
+
+    }
+{% endfor %}

--- a/templates/nginx/serverblock.http.j2
+++ b/templates/nginx/serverblock.http.j2
@@ -1,4 +1,5 @@
 {% set port = port|default(80) %}
+{% set location_file = location_file|d("location-https-redirect.j2") %}
 {% extends "serverblock.j2" %}
 
 {% block location %}
@@ -9,8 +10,4 @@
             default_type text/plain;
         }
     }
-{% endblock %}
-
-{% block main_location %}
-        return 301 https://{{ domainConfig.domain }}$request_uri;
 {% endblock %}

--- a/templates/nginx/serverblock.https.j2
+++ b/templates/nginx/serverblock.https.j2
@@ -1,4 +1,5 @@
 {% set port = port|default(443) %}
+{% set location_file = location_file|d("location-reverseproxy.j2") %}
 {% extends "serverblock.j2" %}
 
 {% block listen_params %}

--- a/templates/nginx/serverblock.j2
+++ b/templates/nginx/serverblock.j2
@@ -1,3 +1,4 @@
+{% set location_file = location_file|d("location.j2") %}
 {% set listen_params_v %}{% block listen_params %}{% endblock %}{% endset %}
 server {
     listen {{ port }} {{ listen_params_v }};
@@ -11,12 +12,5 @@ server {
 
 # Locations
 {% block location %}{% endblock %}
-    location / {
-{% block main_location %}{% endblock %}
-        # Authentication
-{% block authentication %}{% if domainConfig.security.authentication is defined and domainConfig.security.authentication|selectattr("type", "equalto", "basic")|list | length > 0 %}
-        auth_basic           "{{ nginx_basicauth_title }}";
-        auth_basic_user_file "{{ nginx_htpasswd_path }}/.{{ domainConfig.domain }}";
-{% endif %}{% endblock %}
-    }
+{%- include location_file with context %}
 }

--- a/templates/terraform/nginx_server_block_docker.tf.j2
+++ b/templates/terraform/nginx_server_block_docker.tf.j2
@@ -18,10 +18,10 @@ resource "nginx_server_block" "nginx-{{ project_name }}" {
 {%- for nginx_expose in domainConfig.expose if nginx_expose.external_port != 443 %}
 {% set port_index = all_ports|selectattr('service', 'equalto', nginx_expose.service)|selectattr('internal_port', 'equalto', nginx_expose.internal_port)|map(attribute='index')|first %}
 {% if nginx_expose.external_port == 80 %}
-{{ lookup('template', "{{ module_role_path | default(role_path) }}/templates/nginx/serverblock.http.j2", template_vars=dict(domainConfig=ns.domainCfg)) }}
-{{ lookup('template', "{{ module_role_path | default(role_path) }}/templates/nginx/serverblock.container-reverseproxy.j2", template_vars=dict(port_index=port_index,domainConfig=ns.domainCfg)) }}
+{{ lookup('template', "{{ module_role_path | default(role_path) }}/templates/nginx/serverblock.http.j2", template_vars=dict(domainConfig=ns.domainCfg,expose=nginx_expose)) }}
+{{ lookup('template', "{{ module_role_path | default(role_path) }}/templates/nginx/serverblock.https.j2", template_vars=dict(port_index=port_index,expose=nginx_expose,domainConfig=ns.domainCfg)) }}
 {% else %}
-{{ lookup('template', "{{ module_role_path | default(role_path) }}/templates/nginx/serverblock.container-reverseproxy.j2", template_vars=dict(port_index=port_index,port=nginx_expose.external_port,domainConfig=ns.domainCfg)) }}
+{{ lookup('template', "{{ module_role_path | default(role_path) }}/templates/nginx/serverblock.https.j2", template_vars=dict(port_index=port_index,expose=nginx_expose,port=nginx_expose.external_port,domainConfig=ns.domainCfg)) }}
 {% endif %}
 {%- endfor %}
 {%- endfor %}


### PR DESCRIPTION
If an application provides a WebSocket endpoint, its path needs to be proxied separately. Set the paths in expose configuration "proxy_websocket_locations".

Example:
```
expose:
      - internal_port: 8096
        external_port: 80
        service: jellyfin
        proxy_websocket_locations: ['/socket']
```